### PR TITLE
update keyboard prev_rpt atomically

### DIFF
--- a/ps2x2pico.c
+++ b/ps2x2pico.c
@@ -426,7 +426,10 @@ void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
 }
 
 void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
+  uint8_t prev_rpt_snapshot[sizeof(prev_rpt)];
   
+  memcpy(prev_rpt_snapshot, prev_rpt, sizeof(prev_rpt_snapshot));
+
   switch(tuh_hid_interface_protocol(dev_addr, instance)) {
     case HID_ITF_PROTOCOL_KEYBOARD:
       
@@ -459,7 +462,7 @@ void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t cons
           
         }
         
-        prev_rpt[0] = report[0];
+        prev_rpt_snapshot[0] = report[0];
       }
       
       for(uint8_t i = 2; i < 8; i++) {
@@ -515,9 +518,11 @@ void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t cons
           }
         }
         
-        prev_rpt[i] = report[i];
+        prev_rpt_snapshot[i] = report[i];
       }
       
+      memcpy(prev_rpt, prev_rpt_snapshot,  sizeof(prev_rpt));
+
       tuh_hid_receive_report(dev_addr, instance);
       board_led_write(0);
     break;


### PR DESCRIPTION
Modifying previous HID report during parsing of current HID report may lead to spurious PS/2 key presses: some HID devices report 2nd key in a combo by shifting the report to the right and saving that key in the 1st report slot, essentially overwriting the 1st key in prev_rpt. The 1st key in the 2nd slot will be reported once more, as it is missing from prev_rpt.

For example, if I hold T then press P on such a keyboard, it may produce the following HID reports:

```
00 00 17 00 00 00 00 00 // press P
00 00 13 17 00 00 00 00 // press T
```
And here is how `prev_rpt` changes:

```
00 00 17 00 00 00 00 00 // after first report
00 00 13 00 00 00 00 00 // after parsing 0x13 in second report
// when parsing 0x17 in second report, we could not find 0x17 in prev_rpt so another make code for P is sent
00 00 13 17 00 00 00 00 // after parsing 0x17 in second report
```