### PR TITLE
Add compile-time configuration of mouse sample rate behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(PICO_BOARD pico CACHE STRING "Board type")
 
+set(MS_RATE_DEFAULT 100 CACHE STRING "Default mouse sample rate")
+set(MS_RATE_HOST_CONTROL ON CACHE BOOL "Allow the host to configure the mouse sample rate")
+
 # Pull in Raspberry Pi Pico SDK
 include(pico_sdk_import.cmake)
 
@@ -25,6 +28,11 @@ add_compile_definitions(LVPWR=13) # Level shifter pull-up voltage
 add_compile_definitions(KBDAT=11) # Keyboard data pin, clock pin is 12 (data pin+1)
 add_compile_definitions(MSDAT=14) # Mouse data pin, clock pin is 15 (data pin+1)
 add_compile_definitions(PICO_PANIC_FUNCTION=reset)
+
+add_compile_definitions(MS_RATE_DEFAULT=${MS_RATE_DEFAULT})
+if (MS_RATE_HOST_CONTROL)
+    add_compile_definitions(MS_RATE_HOST_CONTROL)
+endif()
 
 pico_set_program_name(ps2x2pico "ps2x2pico")
 pico_set_program_version(ps2x2pico "1.0")

--- a/src/ps2ms.c
+++ b/src/ps2ms.c
@@ -31,7 +31,7 @@ bool ms_streaming = false;
 bool ms_ismoving = false;
 u32 ms_magic_seq = 0;
 u8 ms_type = 0;
-u8 ms_rate = 100;
+u8 ms_rate = MS_RATE_DEFAULT;
 u8 ms_db = 0;
 s16 ms_dx = 0;
 s16 ms_dy = 0;
@@ -135,8 +135,11 @@ void ms_usb_receive(u8 const* report) {
 void ms_receive(u8 byte, u8 prev_byte) {
   switch (prev_byte) {
     case 0xf3: // Set Sample Rate
-      ms_rate = byte;
-      ms_magic_seq = ((ms_magic_seq << 8) | ms_rate) & 0xffffff;
+      #ifdef MS_RATE_HOST_CONTROL
+        ms_rate = byte;
+      #endif
+
+      ms_magic_seq = ((ms_magic_seq << 8) | byte) & 0xffffff;
       
       if(ms_type == 0 && ms_magic_seq == 0xc86450) {
         ms_type = 3;
@@ -153,7 +156,7 @@ void ms_receive(u8 byte, u8 prev_byte) {
           add_alarm_in_ms(100, ms_reset_callback, NULL, false);
           ms_type = 0;
         case 0xf6: // Set Defaults
-          ms_rate = 100;
+          ms_rate = MS_RATE_DEFAULT;
         case 0xf5: // Disable Data Reporting
           ms_streaming = false;
           ms_reset();


### PR DESCRIPTION
Adds two CMake variables:
- `MS_RATE_DEFAULT`: the default mouse sample rate (defualt 100)
- `MS_RATE_HOST_CONTROL`: whether the host should be allowed to change the mouse sample rate (default ON)

Relates to https://github.com/No0ne/ps2x2pico/issues/1#issuecomment-2016936358