### PR TITLE
Note that VBUS == Vin in README diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Keyboard only (incl. PC-XT) variant: https://github.com/No0ne/ps2pico
                   |                 |
 Pico GPIO11 ______| LV1         HV1 |______ PS/2 keyboard data
 Pico GPIO12 ______| LV2         HV2 |______ PS/2 keyboard clock
-Pico GPIO13 ______| LV          HV  |______ PS/2 5V + Pico VBUS
+Pico GPIO13 ______| LV          HV  |______ PS/2 5V + Pico VBUS/Vin
 Pico    GND ______| GND         GND |______ PS/2 GND
 Pico GPIO14 ______| LV3         HV3 |______ PS/2 mouse data
 Pico GPIO15 ______| LV4         HV4 |______ PS/2 mouse clock


### PR DESCRIPTION
Some Pi Pico boards silkscreen `Vin` on the `VBUS` pin and mentioning it by that name would make it simpler for novices to assemble their own ps2x2picos.

...as well as improve the confidence of people like me who had to read a page like [this](https://randomnerdtutorials.com/raspberry-pi-pico-w-pinout-gpios/) that says "The VBUS (USB Power Input) is the micro-USB input voltage. So, if you’re powering the Raspberry Pi Pico via the USB port using 5V, you’ll get 5V on the VBUS pin. " and then think "OK, that's my sanity check. It's being powered by the PS/2 port, so it takes a 5V feed over the Vin pin."