### PR TITLE
Fix alarm callback type for C23

### DIFF
--- a/src/ps2kb.c
+++ b/src/ps2kb.c
@@ -141,7 +141,7 @@ void kb_set_leds(u8 byte) {
   #endif
 }
 
-s64 blink_callback() {
+s64 blink_callback(alarm_id_t, void *) {
   if(blinking) {
     printf("Blinking keyboard LEDs\n");
     kb_set_leds(KEYBOARD_LED_NUMLOCK | KEYBOARD_LED_CAPSLOCK | KEYBOARD_LED_SCROLLLOCK);


### PR DESCRIPTION
alarm_callback_t (the type of function taken by add_alarm_in_ms) takes two arguments. When building with the C23 standard, the argument list of blink_callback has to match this signature, because an empty argument list no longer means arbitrary arguments.

This is only relevant when reusing the ps2x2pico source code outside of the ps2x2pico build system, or when changing CMAKE_C_STANDARD to 23 in CMakeLists.txt.